### PR TITLE
Show the full URL in a timeout error

### DIFF
--- a/lib/http/request/_timeout_listener.js
+++ b/lib/http/request/_timeout_listener.js
@@ -1,12 +1,13 @@
 'use strict';
 
 var error = require('../../error');
+var url = require('url');
 
 module.exports = function onTimeout(context, req, options) {
   return function rejectWithTimeoutError() {
     req.abort();
     var te = new error.TimeoutError(options.timeout);
-    te.url = options.path;
+    te.url = url.format(options);
     return context.reject(te);
   };
 };


### PR DESCRIPTION
For context, please see https://github.com/CondeNast/copilot-util/issues/9.

*tl;dr*: timeout errors in this library only return the request `path`, which can make it difficult to figure out which host was being queried. This PR proposes that we log the full URL which timed out.