### PR TITLE
Fix sinon warnings from 2.2.0 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 # copilot-util
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/CondeNast/copilot-util.svg)](https://greenkeeper.io/)
-
 Condé Nast - copilot JavaScript utilities
 
 [ ![Codeship Status for CondeNast/copilot-util](https://www.codeship.io/projects/a276efc0-4349-0132-7175-3af0e78f4535/status)](https://www.codeship.io/projects/44639)
 [![Code Climate](https://codeclimate.com/github/CondeNast/copilot-util/badges/gpa.svg)](https://codeclimate.com/github/CondeNast/copilot-util)
+[![Greenkeeper badge](https://badges.greenkeeper.io/CondeNast/copilot-util.svg)](https://greenkeeper.io/)
 
 ## Install
 

--- a/test/test-http-request.js
+++ b/test/test-http-request.js
@@ -39,7 +39,7 @@ describe('HTTP', function() {
 
   describe('Request (HTTP)', function() {
     it('should respond with the data mocked into the listener', function(done) {
-      var stub = sinon.stub(http, 'request', requestStub());
+      var stub = sinon.stub(http, 'request').callsFake(requestStub());
       var url = 'http://www.condenast.com';
 
       request(url).done(function(data) {
@@ -62,7 +62,7 @@ describe('HTTP', function() {
 
   describe('Secure Request (HTTPS)', function() {
     it('should respond with the data mocked into the listener', function(done) {
-      var stub = sinon.stub(https, 'request', requestStub());
+      var stub = sinon.stub(https, 'request').callsFake(requestStub());
       var url = 'https://www.condenast.com';
 
       request(url).done(function(data) {
@@ -85,7 +85,7 @@ describe('HTTP', function() {
 
   describe('Request (HTTP) HttpError', function() {
     it('should respond with the data mocked into the listener', function(done) {
-      var stub = sinon.stub(http, 'request', requestStub({ error: true }));
+      var stub = sinon.stub(http, 'request').callsFake(requestStub({ error: true }));
       var url = 'http://www.condenast.com';
 
       request(url).done(null, function(err) {


### PR DESCRIPTION
Removes the test stub deprecation warnings from `sinon`.

```
sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon.
 Use stub(obj, 'meth').callsFake(fn).
 Codemod available at https://github.com/hurrymaplelad/sinon-codemod
```

This change also moves the Greenkeeper badge inline with the others.