### PR TITLE
Use caret semver for devDependencies

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* project: use caret semver for devDependencies and allow Greenkeeper to test updates.
+  This requires fewer package updates and time spent on maintenance.
+
 2016.03.22, Version 3.0.0 (Stable)
 
 * bluebird: Upgrade to 3.3.4

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "immutable": "3.8.1"
   },
   "devDependencies": {
-    "chai": "3.5.0",
-    "eslint": "4.14.0",
-    "mocha": "4.0.1",
-    "sinon": "4.1.5"
+    "chai": "^4.1.2",
+    "eslint": "^4.15.0",
+    "mocha": "^4.1.0",
+    "sinon": "^4.1.6"
   }
 }


### PR DESCRIPTION
Closes https://github.com/CondeNast/copilot-util/pull/38

As part of the broader effort to reduce library maintenance, we are moving to **caret ranges** in devDepenencies for repos using **Greenkeeper**.

- Greenkeeper will create a branch and run CI tests for each individually published package and ensure that in-range versions do not break the build.
- Any failing build will result in an issue opened on the repo.
- A major version release will trigger Greenkeeper to open a PR.

Overall, this should reduce maintenance overhead, not requiring developer action for each published version.