### PR TITLE
WIP: provide the ability to log request timings

### DIFF
--- a/lib/http/request/_request_timing.js
+++ b/lib/http/request/_request_timing.js
@@ -1,0 +1,82 @@
+'use strict';
+
+var times = {};
+var start = function() {};
+var responseCallback = function() {};
+var onSocketCallback = function() {};
+
+if (process.env.HTTP_REQUEST_TIMING) {
+
+  /**
+   * Take a time reading with a specific name, as a delta
+   * from another mark. The second argment is an array of mark names,
+   * so you can specify the time taken to 'firstByte' as as delta
+   * from 'tlsHandshake' for HTTPS connections, or from 'tcpConnection'
+   * for HTTP connections.
+   *
+   * @param {string} name name of the mark to record
+   * @param {array} deltaFrom a list of mark names to use as origin
+   * @returns {undefined} undefined
+   */
+  function timing(name, deltaFrom) {
+    if (!deltaFrom) deltaFrom = [];
+    deltaFrom.push('start');
+
+    return function() {
+      // save this time (absolute)
+      times[name] = process.hrtime();
+
+      if (name !== 'start') {
+        // find the first deltaFrom which is set
+        var timeDelta = deltaFrom.reduce(function(result, timeMarkName) {
+          if (!result && times[timeMarkName]) {
+            return timeMarkName;
+          }
+          return result;
+        }, null);
+
+        var delta = process.hrtime(times[timeDelta]);
+        var ms = Math.round(delta[0] * 1000 + delta[1] / 1000000, 2);
+        console.log(timeDelta, '->', name, ms + 'ms');
+      }
+    }
+  };
+
+  /**
+   * Starts a timing set; call this when the request is made.
+   *
+   * @returns {undefined} undefined
+   */
+  start = function() {
+    timing('start')();
+  };
+
+  /**
+   * Sets up timing marks on a response; use as a callback for
+   * `http.request`.
+   *
+   * @param {Object} res instance of http.ServerResponse
+   * @returns {undefined} undefined
+   */
+  responseCallback = function (res) {
+    res.once('readable', timing('firstByte', ['tlsHandshake', 'tcpConnection']));
+    res.on('end', timing('end', ['firstByte', 'tcpConnection']));
+  };
+
+  /**
+   * Sets up timing marks on a socket; used as a callback for the
+   * request.socket event.
+   *
+   * @param {Object} socket instance of net.Socket
+   * @returns {undefined} undefined
+   */
+  onSocketCallback = function(socket) {
+    socket.on('lookup', timing('dnsLookup'));
+    socket.on('connect', timing('tcpConnection', ['dnsLookup']));
+    socket.on('secureConnect', timing('tlsHandshake', ['tcpConnection']))
+  };
+}
+
+exports.start = start;
+exports.response = responseCallback;
+exports.onSocket = onSocketCallback;

--- a/lib/http/request/_request_timing.js
+++ b/lib/http/request/_request_timing.js
@@ -2,10 +2,21 @@
 
 var times = {};
 var start = function() {};
-var responseCallback = function() {};
-var onSocketCallback = function() {};
+var createResponseCallback = function() {};
+var createSocketCallback = function() {};
+var _ENV = process.env;
 
-if (process.env.HTTP_REQUEST_TIMING) {
+var dogStatsDHost = _ENV.CN_DATADOG_HOST || '127.0.0.1';
+var dogStatsDPort = _ENV.CN_DATADOG_PORT || 8120;
+
+if (_ENV.HTTP_REQUEST_TIMING) {
+
+  var DogStatsD = require('hot-shots');
+  var statsClient = new DogStatsD({
+    host: dogStatsDHost,
+    port: dogStatsDPort,
+    maxBufferSize: 512
+  });
 
   /**
    * Take a time reading with a specific name, as a delta
@@ -16,9 +27,10 @@ if (process.env.HTTP_REQUEST_TIMING) {
    *
    * @param {string} name name of the mark to record
    * @param {array} deltaFrom a list of mark names to use as origin
+   * @param {Array} tags array of tag strings
    * @returns {undefined} undefined
    */
-  function timing(name, deltaFrom) {
+  function timing(name, deltaFrom, tags) {
     if (!deltaFrom) deltaFrom = [];
     deltaFrom.push('start');
 
@@ -37,46 +49,68 @@ if (process.env.HTTP_REQUEST_TIMING) {
 
         var delta = process.hrtime(times[timeDelta]);
         var ms = Math.round(delta[0] * 1000 + delta[1] / 1000000, 2);
-        console.log(timeDelta, '->', name, ms + 'ms');
+        record(name, ms, tags)
       }
     }
   };
 
+  function record(label, value, tags) {
+    console.log(label, value, tags);
+    // statsClient.timing(label, value, tags);
+  }
+
   /**
    * Starts a timing set; call this when the request is made.
    *
+   * @param {Array} tags array of tag strings
    * @returns {undefined} undefined
    */
-  start = function() {
-    timing('start')();
+  start = function(tags) {
+    timing('start', null, tags)();
   };
 
   /**
-   * Sets up timing marks on a response; use as a callback for
-   * `http.request`.
+   * Creates a response callback bound to specific option set
    *
-   * @param {Object} res instance of http.ServerResponse
+   * @param {Array} tags array of tag strings
    * @returns {undefined} undefined
    */
-  responseCallback = function (res) {
-    res.once('readable', timing('firstByte', ['tlsHandshake', 'tcpConnection']));
-    res.on('end', timing('end', ['firstByte', 'tcpConnection']));
+  createResponseCallback = function (tags) {
+    /**
+     * Sets up timing marks on a response; use as a callback for
+     * `http.request`.
+     *
+     * @param {Object} res instance of http.ServerResponse
+     * @returns {undefined} undefined
+     */
+    return function (res) {
+      res.once('readable', timing('firstByte', ['tlsHandshake', 'tcpConnection'], tags));
+      res.on('end', timing('end', ['firstByte', 'tcpConnection'], tags));
+    }
   };
 
   /**
-   * Sets up timing marks on a socket; used as a callback for the
-   * request.socket event.
+   * Creates a socket callback bound to specific option set
    *
-   * @param {Object} socket instance of net.Socket
+   * @param {Array} tags array of tag strings
    * @returns {undefined} undefined
    */
-  onSocketCallback = function(socket) {
-    socket.on('lookup', timing('dnsLookup'));
-    socket.on('connect', timing('tcpConnection', ['dnsLookup']));
-    socket.on('secureConnect', timing('tlsHandshake', ['tcpConnection']))
+  createSocketCallback = function (tags) {
+    /**
+     * Sets up timing marks on a socket; used as a callback for the
+     * request.socket event.
+     *
+     * @param {Object} socket instance of net.Socket
+     * @returns {undefined} undefined
+     */
+    return function(socket) {
+      socket.on('lookup', timing('dnsLookup', null, tags));
+      socket.on('connect', timing('tcpConnection', ['dnsLookup'], tags));
+      socket.on('secureConnect', timing('tlsHandshake', ['tcpConnection'], tags))
+    };
   };
 }
 
 exports.start = start;
-exports.response = responseCallback;
-exports.onSocket = onSocketCallback;
+exports.createResponseCallback = createResponseCallback;
+exports.createSocketCallback = createSocketCallback;

--- a/lib/http/request/index.js
+++ b/lib/http/request/index.js
@@ -5,6 +5,7 @@ var debug = require('debug')('copilot-util:http-request');
 var onError = require('../common/_error_listener');
 var onResponse = require('./_response_listener');
 var onTimeout = require('./_timeout_listener');
+var timingCallbacks = require('./_request_timing');
 var url = require('url');
 
 var _ENV = process.env;
@@ -41,7 +42,9 @@ module.exports = function request(options) {
     var context = { resolve: resolve, reject: reject };
     options.timeout = options.timeout || _SOCKET_TIMEOUT;
 
-    var req = http.request(options);
+    timingCallbacks.start();
+    var req = http.request(options, timingCallbacks.response);
+    req.on('socket', timingCallbacks.onSocket);
 
     // browserify via http-browserify does not currently support timeouts
     // https://github.com/substack/http-browserify/issues/49

--- a/lib/http/request/index.js
+++ b/lib/http/request/index.js
@@ -42,9 +42,11 @@ module.exports = function request(options) {
     var context = { resolve: resolve, reject: reject };
     options.timeout = options.timeout || _SOCKET_TIMEOUT;
 
-    timingCallbacks.start();
-    var req = http.request(options, timingCallbacks.response);
-    req.on('socket', timingCallbacks.onSocket);
+    // create tags for statsD calls
+    var tags = [ options.hostname ];
+    timingCallbacks.start(tags);
+    var req = http.request(options, timingCallbacks.createResponseCallback(tags));
+    req.on('socket', timingCallbacks.createSocketCallback(tags));
 
     // browserify via http-browserify does not currently support timeouts
     // https://github.com/substack/http-browserify/issues/49

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "bluebird": "3.5.0",
     "debug": "3.1.0",
+    "hot-shots": "^5.4.1",
     "immutable": "3.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Issue

When we experience connectivity issues on apps downstream of this repo, we often have no way to understand the source of the problem. If we could log a (sampled) set of timings for parts of the network request, we could graph that and see network latency issues in real-time.

## Approach

Currently, the code switches on and off based on an ENV var (`HTTP_REQUEST_TIMING`). I'd be expecting to add some sampling code in too, to allow apps to throttle how much data they want to report.

Right now, this code simply logs the output, something like this:

```
copilot-util:http-request http request: {COPILOT URL}

start -> dnsLookup 2ms
dnsLookup -> tcpConnection 26ms
tcpConnection -> firstByte 29ms
firstByte -> end 1ms
```

It's an explicit intention here that we'd add in some kind of log handler to do something more useful with this data - probably bucketing it by `host` so that we can identify network issues on a per-provider basis.