### PR TITLE
Enable keep alive

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 * project: update sinon to version ^5.1.0
+* request: enable keepAlive by default
 
 2018.04.12, Version 3.1.0 (Stable)
 

--- a/lib/http/request/index.js
+++ b/lib/http/request/index.js
@@ -6,10 +6,19 @@ var onError = require('../common/_error_listener');
 var onResponse = require('./_response_listener');
 var onTimeout = require('./_timeout_listener');
 var url = require('url');
+var Agent = require('agentkeepalive');
 
 var _ENV = process.env;
 var _MAX_SOCKETS = parseInt(_ENV.NODE_MAX_SOCKETS, 10) || Infinity;
 var _SOCKET_TIMEOUT = parseInt(_ENV.NODE_SOCKET_TIMEOUT, 10) || 15 * 1000;
+
+var _AGENT_OPTIONS= {
+  maxSockets: _MAX_SOCKETS,
+  timeout: _SOCKET_TIMEOUT
+};
+
+var httpAgent = new Agent(_AGENT_OPTIONS);
+var httpAgent = new Agent.HttpsAgent(_AGENT_OPTIONS);
 
 /**
  * Request data over HTTP/s
@@ -30,8 +39,7 @@ module.exports = function request(options) {
   var http = options.secure ? require('https') : require('http');
 
   if (!options.agent) {
-    options.agent = new http.Agent();
-    options.agent.maxSockets = _MAX_SOCKETS;
+    options.agent = options.secure ? httpsAgent : httpAgent;
   }
 
   var protocol = 'http' + (options.secure ? 's' : '') + '://';

--- a/lib/http/request/index.js
+++ b/lib/http/request/index.js
@@ -12,13 +12,13 @@ var _ENV = process.env;
 var _MAX_SOCKETS = parseInt(_ENV.NODE_MAX_SOCKETS, 10) || Infinity;
 var _SOCKET_TIMEOUT = parseInt(_ENV.NODE_SOCKET_TIMEOUT, 10) || 15 * 1000;
 
-var _AGENT_OPTIONS= {
+var _AGENT_OPTIONS = {
   maxSockets: _MAX_SOCKETS,
   timeout: _SOCKET_TIMEOUT
 };
 
 var httpAgent = new Agent(_AGENT_OPTIONS);
-var httpAgent = new Agent.HttpsAgent(_AGENT_OPTIONS);
+var httpsAgent = new Agent.HttpsAgent(_AGENT_OPTIONS);
 
 /**
  * Request data over HTTP/s

--- a/lib/http/request/index.js
+++ b/lib/http/request/index.js
@@ -13,6 +13,7 @@ var _MAX_SOCKETS = parseInt(_ENV.NODE_MAX_SOCKETS, 10) || Infinity;
 var _SOCKET_TIMEOUT = parseInt(_ENV.NODE_SOCKET_TIMEOUT, 10) || 15 * 1000;
 
 var _AGENT_OPTIONS = {
+  keepAlive: true,
   maxSockets: _MAX_SOCKETS,
   timeout: _SOCKET_TIMEOUT
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/CondeNast/copilot-util",
   "license": "MIT",
   "dependencies": {
+    "agentkeepalive": "3.5.1",
     "bluebird": "3.5.1",
     "debug": "3.2.2",
     "immutable": "3.8.1"


### PR DESCRIPTION
Use agentkeepalive to manage the Agents which has the following benefits:
 - keepAlive is on by default
 - sets `maxFreeSockets` to 256
 - Disable Nagle's algorithm on the underlying socket.

https://github.com/node-modules/agentkeepalive