### PR TITLE
[DO NOT MERGE] Add env var to load native promises

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019.09.03, Version 3.2.0-exp-allow-native-promises.1 (Experimental)
+* Add env var to opt-in to native promises
+
 2018.10.16, Version 3.2.0 (Stable)
 * project: update sinon to version ^5.1.0
 * request: enable keepAlive by default

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var USE_NATIVE_PROMISES = process.env.PROMISE_TYPE === 'native';
+var USE_NATIVE_PROMISES = process.env.COPILOT_PROMISE_TYPE === 'native';
 
 /**
  * Core dependencies

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -1,7 +1,11 @@
 'use strict';
 
+var USE_NATIVE_PROMISES = process.env.PROMISE_TYPE === 'native';
+
 /**
  * Core dependencies
  */
-exports.Promise = require('bluebird');
+exports.Promise = USE_NATIVE_PROMISES
+ ? Promise
+ : require('bluebird');
 exports.collection = require('immutable');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-util",
-  "version": "3.2.0",
+  "version": "3.2.0-exp-allow-native-promises.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-util",
-  "version": "3.2.0",
+  "version": "3.2.0-exp-allow-native-promises.1",
   "description": "Condé Nast - copilot JavaScript utilities",
   "main": "lib/index.js",
   "scripts": {

--- a/test/test-core-interface.js
+++ b/test/test-core-interface.js
@@ -25,7 +25,7 @@ describe('Core', function() {
     describe('Native Promises', function() {
       before(function () {
         // Reload the library using native promises
-        process.env.PROMISE_TYPE = 'native';
+        process.env.COPILOT_PROMISE_TYPE = 'native';
 
         // Delete the cached modules
         delete require.cache[require.resolve('..')];
@@ -37,7 +37,7 @@ describe('Core', function() {
 
       after(function () {
         // Reload the library using default Bluebird promises
-        delete process.env.PROMISE_TYPE;
+        delete process.env.COPILOT_PROMISE_TYPE;
 
         // Delete the cached modules
         delete require.cache[require.resolve('..')];

--- a/test/test-core-interface.js
+++ b/test/test-core-interface.js
@@ -5,15 +5,56 @@ var expect = require('chai').expect;
 
 describe('Core', function() {
   describe('Interface', function() {
-    it('should export a promise implementation', function() {
-      expect(core.Promise).to.be.a('function');
-      expect(core.Promise.resolve).to.be.a('function');
-    });
-
     it('should export a collection implementation', function() {
       expect(core.collection).to.be.a('object');
       expect(core.collection.List).to.be.a('function');
       expect(core.collection.Set).to.be.a('function');
+    });
+
+    describe('Bluebird Promises', function() {
+      it('should export a promise implementation', function() {
+        expect(core.Promise).to.be.a('function');
+        expect(core.Promise.resolve).to.be.a('function');
+      });
+
+      it('should have bluebird specific method', function () {
+        expect(core.Promise.props).to.be.a('function');
+      });
+    });
+
+    describe('Native Promises', function() {
+      before(function () {
+        // Reload the library using native promises
+        process.env.PROMISE_TYPE = 'native';
+
+        // Delete the cached modules
+        delete require.cache[require.resolve('..')];
+        delete require.cache[require.resolve('../lib/core')];
+
+        // Reload the module(s) using native Promises
+        core = require('..').core;
+      });
+
+      after(function () {
+        // Reload the library using default Bluebird promises
+        delete process.env.PROMISE_TYPE;
+
+        // Delete the cached modules
+        delete require.cache[require.resolve('..')];
+        delete require.cache[require.resolve('../lib/core')];
+
+        // Reload the module(s) using Bluebird Promises
+        core = require('..').core;
+      });
+
+      it('should export a promise implementation', function() {
+        expect(core.Promise).to.be.a('function');
+        expect(core.Promise.resolve).to.be.a('function');
+      });
+
+      it('should not have bluebird specific method', function () {
+        expect(core.Promise.props).to.equal(undefined);
+      });
     });
   });
 });


### PR DESCRIPTION
While doing some profiling, I've noticed that the Bluebird promises _may_ have a blocking effect. My understanding is that by default, Bluebird uses `setImmediate` to queue promise callbacks, whereas native promises use `nextTick`. Because so many promise callbacks are queued, the immediate queue appears to get backed up. This results in large `processImmediate` events in the profile (e.g., 1.68s). 

<img width="1482" alt="Screen Shot 2019-08-30 at 10 16 20 AM" src="https://user-images.githubusercontent.com/921795/64032199-8c483080-cb0f-11e9-9169-8f90aac07168.png">

I'm seeing these get larger and larger over the lifetime of a profile. Using [blocked-at](https://github.com/naugtur/blocked-at), I'm finding that the event loop is blocked (warning: I'm not sure I 100% trust this tool yet).

Switching the Promise implementation to use native Promises, I find that this issue is avoided altogether. I see no long events in the profile and blocked-at does not indicate any blocking.

<img width="1481" alt="Screen Shot 2019-08-30 at 10 19 27 AM" src="https://user-images.githubusercontent.com/921795/64032357-e5b05f80-cb0f-11e9-9e33-f877d1eb8bda.png">

The longest events I'm seeing with native Promises are around 250ms.

Another piece of evidence that suggests blocking is with regard to the number of times `parseExecutor` is called in the different profiles. At different points in the request chain, `copilot-util`'s `parse` method is called, which then calls `parseExecutor`. Under the same load, I'm finding the the Bluebird Promises condition called `parseExecutor` 7 times in 20 seconds, whereas the native Promise condition called `parseExecutor` 585 times. This suggests that Native Promises lead to more processing than Bluebird during the same time period.

The main counter evidence is that regardless of condition, I'm still seeing event loop delay times higher than 1s. The two conditions perform equally in this regard. I don't know how to square this information with the blocked-at results. One possibility is that our metrics for measuring "event loop delay" are really measuring something that is not quite event loop delay. It's a very confusing topic and I'd be surprised it we were getting it right.

I think we might be seeing some better performance characteristics with Native Promises with regard to managing heavier workloads. I would like to test this in some services. Thus, I want to offer the environment variable to allow for easy testing. Should we provide evidence that this is indeed a worthy performance change, we can undertake the effort to fully transition to Native Promises.