### PR TITLE
[Proof of concept] TT-2824 related: remove gzip from compress headers

### DIFF
--- a/lib/internal/compress/index.js
+++ b/lib/internal/compress/index.js
@@ -4,7 +4,7 @@ var core = require('../../core');
 var zlib = require('zlib');
 
 /*eslint new-cap:0 */
-var _COMPRESS_HEADERS = core.collection.Set(['gzip', 'deflate', 'identity']);
+var _COMPRESS_HEADERS = core.collection.Set(['deflate', 'identity']);
 
 function errorOr(context) {
   return function errorOrBuffer(err, buf) {


### PR DESCRIPTION

Bumping the `autopilot-server-data` plugin to v2 on self brand, I face an issue; the request was not getting passed to the FE. Debugging the request chain, I found out that the request was breaking in this part `https://github.com/CondeNast/autopilot-server-plugins/blob/f7493071a19c04a44b9a9d9bedd6e4fb4acc82fa/packages/data/utils/server.js#L78`. and narrow it down, I arrive to the `zlib.unzip` call.

For some reason, the `zlib.unzip` function breaks with [this](http://api.condenast.io/v1/recommendations?brand=self&applicationID=self-article&brandName=self&page%5Bsize%5D=6&url=https%3A%2F%2Fwww.self.com%2Fstory%2Fhpv-vaccine-advocate) kind of response. 

The error is: 
```
{ Error: incorrect header check
    at Zlib._handle.onerror (zlib.js:371:17)
From previous event:
    at Object.unzip (/Users/intellisys/conde/autopilot-self/node_modules/@condenast/autopilot-server-plugin-data/node_modules/copilot-util/lib/internal/compress/index.js:23:10)
    at IncomingMessage.resolveData (/Users/intellisys/conde/autopilot-self/node_modules/@condenast/autopilot-server-plugin-data/node_modules/copilot-util/lib/http/response/_end_listener.js:19:26)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:978:12)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickDomainCallback (internal/process/next_tick.js:128:9) errno: -3, code: 'Z_DATA_ERROR' 
}
```
I tried to debugg this, I couldnt find the way to pass the correct headers to this function. 

So, removing the `gzip` value from the compressed headers it will return it as is...It should braks down the line since the content is gzipped, but its not. 

