### PR TITLE
fix(core): remove bluebird in favor of native Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ npm run-script examples
   * <a href="#error_http"><code><b>error.HttpError()</b></code></a>
   * <a href="#error_timeout"><code><b>error.TimeoutError()</b></code></a>
   * <a href="#json_parse"><code><b>json.parse()</b></code></a>
-  * <a href="#core_promise"><code><b>core.Promise()</b></code></a>
   * <a href="#core_collection"><code><b>core.collection()</b></code></a>
 
 ---
@@ -61,9 +60,6 @@ npm run-script examples
 
 ---
 ### Core
-
-<a name="core_promise"></a>
-see: [bluebird API](https://github.com/petkaantonov/bluebird/blob/master/API.md) <code>([module](lib/core))</code>
 
 <a name="core_collection"></a>
 see: [immutable API](http://facebook.github.io/immutable-js) <code>([module](lib/core))</code>

--- a/examples/http-request.js
+++ b/examples/http-request.js
@@ -10,10 +10,10 @@ var options = {
   }
 };
 
-request(options).then(response).done(function(buffer) {
+request(options).then(response).then(function(buffer) {
   console.log(buffer.toString().length);
 });
 
-request('http://www.google.com').then(response).done(function(buffer) {
+request('http://www.google.com').then(response).then(function(buffer) {
   console.log(buffer.toString().length);
 });

--- a/examples/https-request.js
+++ b/examples/https-request.js
@@ -11,10 +11,10 @@ var options = {
   }
 };
 
-request(options).then(response).done(function(buffer) {
+request(options).then(response).then(function(buffer) {
   console.log(buffer.toString().length);
 });
 
-request('https://www.google.com').then(response).done(function(buffer) {
+request('https://www.google.com').then(response).then(function(buffer) {
   console.log(buffer.toString().length);
 });

--- a/examples/json-parse.js
+++ b/examples/json-parse.js
@@ -16,12 +16,12 @@ var options = {
   timeout: 3000
 };
 
-request(options).then(parse).done(function(json) {
+request(options).then(parse).then(function(json) {
   console.log(json);
 });
 
 // note: this version will not send compression headers
 // note: this version will respect the default socket timeout
-request('https://graph.facebook.com/ping').then(parse).done(function(json) {
+request('https://graph.facebook.com/ping').then(parse).then(function(json) {
   console.log(json);
 });

--- a/examples/response-filter.js
+++ b/examples/response-filter.js
@@ -11,13 +11,13 @@ var options = {
   }
 };
 
-request(options).then(identity).then(response).done(function(buffer) {
+request(options).then(identity).then(response).then(function(buffer) {
   console.log(buffer.toString().length);
 });
 
 request('http://www.google.com')
   .then(identity)
   .then(response)
-  .done(function(buffer) {
+  .then(function(buffer) {
     console.log(buffer.toString().length);
   });

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -3,5 +3,4 @@
 /**
  * Core dependencies
  */
-exports.Promise = require('bluebird');
 exports.collection = require('immutable');

--- a/lib/filter/_identity_filter.js
+++ b/lib/filter/_identity_filter.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var core = require('../core');
-
 /**
  * A filter that returns the identity or same value as the response
  *
@@ -9,5 +7,5 @@ var core = require('../core');
  * @returns {Promise~Response}
  */
 module.exports = function identity(res) {
-  return core.Promise.resolve(res);
+  return Promise.resolve(res);
 };

--- a/lib/http/request/index.js
+++ b/lib/http/request/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var core = require('../../core');
 var debug = require('debug')('copilot-util:http-request');
 var onError = require('../common/_error_listener');
 var onResponse = require('./_response_listener');
@@ -46,7 +45,7 @@ module.exports = function request(options) {
   var protocol = 'http' + (options.secure ? 's' : '') + '://';
   debug('http request: %s', protocol + options.hostname + options.path);
 
-  return new core.Promise(function requestExecutor(resolve, reject) {
+  return new Promise(function requestExecutor(resolve, reject) {
     var context = { resolve: resolve, reject: reject };
     options.timeout = options.timeout || _SOCKET_TIMEOUT;
 

--- a/lib/http/response/index.js
+++ b/lib/http/response/index.js
@@ -13,7 +13,7 @@ var onError = require('../common/_error_listener');
  * @returns {Promise~Response}
  */
 module.exports = function onResponse(res) {
-  return new core.Promise(function responseExecutor(resolve, reject) {
+  return new Promise(function responseExecutor(resolve, reject) {
     var context = { resolve: resolve, reject: reject };
 
     /*eslint new-cap:0 */

--- a/lib/internal/compress/index.js
+++ b/lib/internal/compress/index.js
@@ -20,7 +20,7 @@ function errorOr(context) {
  * @returns {Promise~Buffer}
  */
 exports.unzip = function unzip(res, buffer) {
-  return new core.Promise(function unzipExecutor(resolve, reject) {
+  return new Promise(function unzipExecutor(resolve, reject) {
     if (res.headers['content-encoding'] === 'identity') {
       return resolve(buffer);
     }

--- a/lib/json/index.js
+++ b/lib/json/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var core = require('../core');
-
 /**
  * Parse JSON from a string or buffer
  *
@@ -9,7 +7,7 @@ var core = require('../core');
  * @returns {Promise~String}
  */
 exports.parse = function parse(data) {
-  return new core.Promise(function parseExecutor(resolve) {
+  return new Promise(function parseExecutor(resolve) {
     return resolve(JSON.parse(data));
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -266,11 +266,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "dependencies": {
     "agentkeepalive": "4.1.0",
-    "bluebird": "3.7.2",
     "debug": "4.1.1",
     "immutable": "3.8.2"
   },

--- a/test/test-compress.js
+++ b/test/test-compress.js
@@ -21,7 +21,7 @@ describe('Compress', function() {
 
       zlib.gzip(new Buffer(str), function(err, buffer) {
         expect(err).to.equal(null);
-        compress.unzip(res, buffer).done(function(buf) {
+        compress.unzip(res, buffer).then(function(buf) {
           expect(buf.toString()).to.equal(str);
 
           done();
@@ -34,7 +34,7 @@ describe('Compress', function() {
 
       zlib.deflate(new Buffer(str), function(err, buffer) {
         expect(err).to.equal(null);
-        compress.unzip(res, buffer).done(function(buf) {
+        compress.unzip(res, buffer).then(function(buf) {
           expect(buf.toString()).to.equal(str);
 
           done();
@@ -45,7 +45,7 @@ describe('Compress', function() {
     it('should reject non-buffer data', function(done) {
       res.headers['content-encoding'] = 'deflate';
 
-      compress.unzip(res, str).done(null, function(err) {
+      compress.unzip(res, str).then(null, function(err) {
         expect(err.code).to.eql('Z_DATA_ERROR');
 
         done();
@@ -55,7 +55,7 @@ describe('Compress', function() {
     it('should not uncompress identity response data', function(done) {
       res.headers['content-encoding'] = 'identity';
 
-      compress.unzip(res, new Buffer(str)).done(function(buf) {
+      compress.unzip(res, new Buffer(str)).then(function(buf) {
         expect(buf.toString()).to.equal(str);
 
         done();
@@ -65,7 +65,7 @@ describe('Compress', function() {
     it('should ignore empty/other encodings', function(done) {
       res.headers['content-encoding'] = '';
 
-      compress.unzip(res, new Buffer(str)).done(function(buf) {
+      compress.unzip(res, new Buffer(str)).then(function(buf) {
         expect(buf.toString()).to.equal(str);
 
         done();

--- a/test/test-core-interface.js
+++ b/test/test-core-interface.js
@@ -5,11 +5,6 @@ var expect = require('chai').expect;
 
 describe('Core', function() {
   describe('Interface', function() {
-    it('should export a promise implementation', function() {
-      expect(core.Promise).to.be.a('function');
-      expect(core.Promise.resolve).to.be.a('function');
-    });
-
     it('should export a collection implementation', function() {
       expect(core.collection).to.be.a('object');
       expect(core.collection.List).to.be.a('function');

--- a/test/test-filter-identity.js
+++ b/test/test-filter-identity.js
@@ -17,7 +17,7 @@ describe('Identity Filter', function() {
   };
 
   it('should return the same response it received', function(done) {
-    filter.identity(res).done(function(value) {
+    filter.identity(res).then(function(value) {
       expect(value).to.eql(res);
 
       done();

--- a/test/test-http-request.js
+++ b/test/test-http-request.js
@@ -43,7 +43,7 @@ describe('HTTP', function() {
       var stub = sinon.stub(http, 'request').callsFake(requestStub());
       var url = 'http://www.condenast.com';
 
-      request(url).done(function(data) {
+      request(url).then(function(data) {
         var args = stub.args[0][0];
         expect(args.protocol).to.eql('http:');
         expect(args.href).to.eql(url + '/');
@@ -66,7 +66,7 @@ describe('HTTP', function() {
       var stub = sinon.stub(https, 'request').callsFake(requestStub());
       var url = 'https://www.condenast.com';
 
-      request(url).done(function(data) {
+      request(url).then(function(data) {
         var args = stub.args[0][0];
         expect(args.protocol).to.eql('https:');
         expect(args.href).to.eql(url + '/');
@@ -89,7 +89,7 @@ describe('HTTP', function() {
       var stub = sinon.stub(http, 'request').callsFake(requestStub({ error: true }));
       var url = 'http://www.condenast.com';
 
-      request(url).done(null, function(err) {
+      request(url).then(null, function(err) {
         var args = stub.args[0][0];
         expect(args.protocol).to.eql('http:');
         expect(args.href).to.eql(url + '/');

--- a/test/test-http-response.js
+++ b/test/test-http-response.js
@@ -20,7 +20,7 @@ describe('HTTP', function() {
       rs.headers = {};
       rs.destroy = function() { /* close socket */ };
 
-      response(rs).done(function(data) {
+      response(rs).then(function(data) {
         expect(data.toString()).to.eql(str);
 
         done();
@@ -41,7 +41,7 @@ describe('HTTP', function() {
         'content-encoding': 'gzip'
       };
 
-      response(zrs).done(function(data) {
+      response(zrs).then(function(data) {
         expect(data.toString()).to.eql(str);
 
         done();
@@ -59,7 +59,7 @@ describe('HTTP', function() {
       rs.headers = {};
       rs.destroy = function() { /* close socket */ };
 
-      response(rs).done(null, function(err) {
+      response(rs).then(null, function(err) {
         expect(err.message).to.eql('Bad Request');
 
         done();

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -10,7 +10,7 @@ describe('JSON', function() {
 
   describe('parse', function() {
     it('should convert a JSON string into an object', function(done) {
-      json.parse(JSON.stringify(data)).done(function(obj) {
+      json.parse(JSON.stringify(data)).then(function(obj) {
         expect(obj).to.eql(data);
 
         done();
@@ -18,7 +18,7 @@ describe('JSON', function() {
     });
 
     it('should convert a buffer with JSON into an object', function(done) {
-      json.parse(new Buffer(JSON.stringify(data))).done(function(obj) {
+      json.parse(new Buffer(JSON.stringify(data))).then(function(obj) {
         expect(obj).to.eql(data);
 
         done();
@@ -26,7 +26,7 @@ describe('JSON', function() {
     });
 
     it('should convert a buffer with JSON into an object', function(done) {
-      json.parse(new Buffer(JSON.stringify(data))).done(function(obj) {
+      json.parse(new Buffer(JSON.stringify(data))).then(function(obj) {
         expect(obj).to.eql(data);
 
         done();
@@ -36,7 +36,7 @@ describe('JSON', function() {
     it('should reject invalid JSON', function(done) {
       var token = '>';
 
-      json.parse(JSON.stringify(data) + token).done(null, function(err) {
+      json.parse(JSON.stringify(data) + token).then(null, function(err) {
         expect(err).to.be.an.instanceof(SyntaxError);
         expect(err.message).to.contain(token);
 


### PR DESCRIPTION
BREAKING CHANGE

Supersedes https://github.com/CondeNast/copilot-util/pull/71

This project has already been updated to require node 8+ (and will likely be updated to require node 10+). It does not need to use `bluebird` for promises anymore.
- Remove dependency `bluebird`
- Use native `Promise` interface
- Remove exported `core.Promise` (will require consumers to update accordingly)

For discussion:
- We _could_ still export `core.Promise` (as a native `Promise`) rather than break that interface, but I think it's better to just tear off the band-aid