### PR TITLE
chore: update tests to use Buffer.from instead of deprecated Buffer constructor

### DIFF
--- a/test/test-compress.js
+++ b/test/test-compress.js
@@ -19,7 +19,7 @@ describe('Compress', function() {
     it('should uncompress gzip response data', function(done) {
       res.headers['content-encoding'] = 'gzip';
 
-      zlib.gzip(new Buffer(str), function(err, buffer) {
+      zlib.gzip(Buffer.from(str), function(err, buffer) {
         expect(err).to.equal(null);
         compress.unzip(res, buffer).then(function(buf) {
           expect(buf.toString()).to.equal(str);
@@ -32,7 +32,7 @@ describe('Compress', function() {
     it('should uncompress deflate response data', function(done) {
       res.headers['content-encoding'] = 'deflate';
 
-      zlib.deflate(new Buffer(str), function(err, buffer) {
+      zlib.deflate(Buffer.from(str), function(err, buffer) {
         expect(err).to.equal(null);
         compress.unzip(res, buffer).then(function(buf) {
           expect(buf.toString()).to.equal(str);
@@ -55,7 +55,7 @@ describe('Compress', function() {
     it('should not uncompress identity response data', function(done) {
       res.headers['content-encoding'] = 'identity';
 
-      compress.unzip(res, new Buffer(str)).then(function(buf) {
+      compress.unzip(res, Buffer.from(str)).then(function(buf) {
         expect(buf.toString()).to.equal(str);
 
         done();
@@ -65,7 +65,7 @@ describe('Compress', function() {
     it('should ignore empty/other encodings', function(done) {
       res.headers['content-encoding'] = '';
 
-      compress.unzip(res, new Buffer(str)).then(function(buf) {
+      compress.unzip(res, Buffer.from(str)).then(function(buf) {
         expect(buf.toString()).to.equal(str);
 
         done();

--- a/test/test-http-request.js
+++ b/test/test-http-request.js
@@ -8,7 +8,7 @@ var sinon = require('sinon');
 var PassThrough = require('stream').PassThrough;
 
 describe('HTTP', function() {
-  var buf = new Buffer('渚 カヲル Nagisa Kaoru');
+  var buf = Buffer.from('渚 カヲル Nagisa Kaoru');
 
   var setTimeoutSpy = sinon.spy();
   var endSpy = sinon.spy();

--- a/test/test-http-response.js
+++ b/test/test-http-response.js
@@ -12,7 +12,7 @@ describe('HTTP', function() {
     it('should transmit response data', function(done) {
       var rs = new stream.Readable();
       rs._read = function() {
-        this.push(new Buffer(str));
+        this.push(Buffer.from(str));
         this.push(null);
       };
       rs.method = 'GET';
@@ -30,7 +30,7 @@ describe('HTTP', function() {
     it('should automatically handle compressed data', function(done) {
       var rs = new stream.Readable();
       rs._read = function() {
-        this.push(new Buffer(str));
+        this.push(Buffer.from(str));
         this.push(null);
       };
 
@@ -51,7 +51,7 @@ describe('HTTP', function() {
     it('should reject error HTTP statuses', function(done) {
       var rs = new stream.Readable();
       rs._read = function() {
-        this.push(new Buffer(str));
+        this.push(Buffer.from(str));
         this.push(null);
       };
       rs.method = 'GET';

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -18,7 +18,7 @@ describe('JSON', function() {
     });
 
     it('should convert a buffer with JSON into an object', function(done) {
-      json.parse(new Buffer(JSON.stringify(data))).then(function(obj) {
+      json.parse(Buffer.from(JSON.stringify(data))).then(function(obj) {
         expect(obj).to.eql(data);
 
         done();
@@ -26,7 +26,7 @@ describe('JSON', function() {
     });
 
     it('should convert a buffer with JSON into an object', function(done) {
-      json.parse(new Buffer(JSON.stringify(data))).then(function(obj) {
+      json.parse(Buffer.from(JSON.stringify(data))).then(function(obj) {
         expect(obj).to.eql(data);
 
         done();


### PR DESCRIPTION
Only appears in test code.

> DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
